### PR TITLE
SVC-20214: Support zsh without giving error messages to users

### DIFF
--- a/templates/history.sh.erb
+++ b/templates/history.sh.erb
@@ -1,6 +1,12 @@
 # This file is managed by Puppet.
 export HISTTIMEFORMAT="%h %d %H:%M:%S "
 export HISTSIZE=<%= @size %>
-shopt -s histappend
-shopt -s cmdhist
 export HISTFILE=~/.bash_<%= @filename %>
+if type shopt &>/dev/null ; then
+  # BASH
+  shopt -s histappend
+  shopt -s cmdhist
+elif type setopt &>/dev/null ; then
+  # ZSH
+  setopt APPEND_HISTORY
+fi

--- a/templates/timeout.sh.erb
+++ b/templates/timeout.sh.erb
@@ -1,5 +1,10 @@
 # This file is managed by Puppet.
 # TMOUT IN SECONDS
-TMOUT=<%= @session_seconds %>
-readonly TMOUT
-export TMOUT
+#[ ! -z "$TMOUT" ] && echo "Session TMOUT already set"
+if type shopt &>/dev/null ; then
+  # BASH
+  [ -z "$TMOUT" ] && TMOUT=<%= @session_seconds %> && readonly TMOUT && export TMOUT
+elif type setopt &>/dev/null ; then
+  # ZSH
+  [ -z "$TMOUT" ] && TMOUT=<%= @session_seconds %> && typeset -gxr TMOUT
+fi


### PR DESCRIPTION
See: https://jira.ncsa.illinois.edu/browse/SVC-20214

Apparently `zsh` references `/etc/profile.d/*.sh` files, but the 2 new files that were put in place by this module contained commands that do not work with `zsh`. So, I updated the 2 `/etc/profile.d/*.sh` scripts here to do different things depending if bash vs zsh.

This is being tested on `linux-test`.