### PR TITLE
SVCPLAN-1633: Distinct root history per-sudo-user

### DIFF
--- a/templates/history.csh.erb
+++ b/templates/history.csh.erb
@@ -1,6 +1,10 @@
 # This file is managed by Puppet.
 set savehist=<%= @size %>
 set history= ( <%= @size %> "%h %Y-%W-%D %T %R\n" )
-set histfile = ~/.csh_<%= @filename %>
+if ( $?SUDO_USER ) then
+  set histfile = ~/.csh_${SUDO_USER}_<%= @filename %>
+else
+  set histfile = ~/.csh_<%= @filename %>
+endif
 set histappend
 set cmdhist

--- a/templates/history.sh.erb
+++ b/templates/history.sh.erb
@@ -1,7 +1,11 @@
 # This file is managed by Puppet.
 export HISTTIMEFORMAT="%h %d %H:%M:%S "
 export HISTSIZE=<%= @size %>
-export HISTFILE=~/.bash_<%= @filename %>
+if [ -n "$SUDO_USER" ]; then
+  export HISTFILE=~/.bash_${SUDO_USER}_<%= @filename %>
+else
+  export HISTFILE=~/.bash_<%= @filename %>
+fi
 if type shopt &>/dev/null ; then
   # BASH
   shopt -s histappend


### PR DESCRIPTION
Fix #3 & Fix https://github.com/ncsa/xcat-tools/issues/17
See https://jira.ncsa.illinois.edu/browse/SVCPLAN-1633

This has been tested on the following hosts:
```
control-test-centos7a
control-test-rhel7a
control-test-rhel84a
control-test-rhel8a
control-test-rhel9a
```

Below are some useful commands for testing this:
```
# SSH AS NORMAL USER
sudo -i
  uptime; hostname; w;
  exit
sudo -i
  ls -lah ~/.*commands.log
  exit
sudo su -s /bin/csh
  uptime; hostname; w;
  exit
sudo -i
  ls -lah ~/.*commands.log
  su -s /bin/csh
    exit
  ls -lah ~/.*commands.log
  exit
ls -lah ~/.*commands.log
exit

# FOR QUALYS EXAMPLE
XCATSERVER="asd-prov01"
TESTHOST="control-test-rhel84a.internal.ncsa.edu"
ssh ${XCATSERVER}
sudo -i
  ssh ${TESTHOST}  ## TEST WITH BASH
  sudo su - qualys
    sudo -i
      exit
    ls -lah ~/.*commands.log
    exit
  ssh ${TESTHOST} -t su -s /bin/csh ## TEST WITH CSH
    echo $SHELL
    uptime; hostname; w;
    exit
  ssh ${TESTHOST}
    ls -lah ~/.*commands.log    
  exit
```