### PR TITLE
SVCPLAN-2163: Add history support for parent user & ignore qualys in …

### DIFF
--- a/templates/history.csh.erb
+++ b/templates/history.csh.erb
@@ -1,8 +1,20 @@
 # This file is managed by Puppet.
 set savehist=<%= @size %>
 set history= ( <%= @size %> "%h %Y-%W-%D %T %R\n" )
-if ( $?SUDO_USER ) then
-  set histfile = ~/.csh_${SUDO_USER}_<%= @filename %>
+
+# GET PARENT USER OF CURRENT USER
+set thisPID=$$
+set origUser=`whoami`
+set thisUser="$origUser"
+while ( "$thisUser" == "$origUser" && "$thisPID" != "0")
+    set ARR=`ps h -p$thisPID -ouser,ppid;`
+    set thisUser=`echo $ARR | awk '{ print $1 }'`
+    set thisPID=`echo $ARR | awk '{ print $NF }'`
+end
+set PARENT_USER=`getent passwd "$thisUser" | cut -d: -f1`
+
+if ( "$PARENT_USER" != "root" && "$USER" != "$PARENT_USER" ) then
+  set histfile = ~/.csh_${PARENT_USER}_<%= @filename %>
 else
   set histfile = ~/.csh_<%= @filename %>
 endif

--- a/templates/history.sh.erb
+++ b/templates/history.sh.erb
@@ -1,10 +1,27 @@
 # This file is managed by Puppet.
 export HISTTIMEFORMAT="%h %d %H:%M:%S "
 export HISTSIZE=<%= @size %>
-if [ -n "$SUDO_USER" ]; then
-  export HISTFILE=~/.bash_${SUDO_USER}_<%= @filename %>
+
+# GET PARENT USER OF CURRENT USER
+thisPID=$$
+origUser=$(whoami)
+thisUser=$origUser
+while [ "$thisUser" == "$origUser" -a "$thisPID" != "0" ]
+do
+    ARR=($(ps h -p$thisPID -ouser,ppid;))
+    thisUser="${ARR[0]}"
+    myPPid="${ARR[1]}"
+    thisPID=$myPPid
+done
+PARENT_USER=$(getent passwd "$thisUser" | cut -d: -f1)
+
+if [ "$PARENT_USER" != "root" -a "$USER" != "$PARENT_USER" ]; then
+  export HISTFILE=~/.sh_${PARENT_USER}_<%= @filename %>
 else
-  export HISTFILE=~/.bash_<%= @filename %>
+  export HISTFILE=~/.sh_<%= @filename %>
+  if [ "$USER" == "root" ]; then
+    export HISTIGNORE=*QUALYS*:*ORIG_PATH*:echo\ *TEST*
+  fi
 fi
 if type shopt &>/dev/null ; then
   # BASH


### PR DESCRIPTION
```
SVCPLAN-2163: Add history support for parent user & ignore qualys in root history

Update history.sh & history.csh to use PARENTUSER logic
Change bash/sh/zsh history files to be prefixed with '.sh_' instead of '.bash_'
```

This has been tested on:
- `control-test-centos7a`
- `control-test-rhel8a`
- `control-test-rhel9a`
- `control-test-rocky8a`