### PR TITLE
SVCPLAN-2163: Switch back to using .bash prefix for sh script

### DIFF
--- a/templates/history.sh.erb
+++ b/templates/history.sh.erb
@@ -16,9 +16,9 @@ done
 PARENT_USER=$(getent passwd "$thisUser" | cut -d: -f1)
 
 if [ "$PARENT_USER" != "root" -a "$USER" != "$PARENT_USER" ]; then
-  export HISTFILE=~/.sh_${PARENT_USER}_<%= @filename %>
+  export HISTFILE=~/.bash_${PARENT_USER}_<%= @filename %>
 else
-  export HISTFILE=~/.sh_<%= @filename %>
+  export HISTFILE=~/.bash_<%= @filename %>
   if [ "$USER" == "root" ]; then
     export HISTIGNORE=*QUALYS*:*ORIG_PATH*:echo\ *TEST*
   fi


### PR DESCRIPTION
Revert back to using the `.bash_` prefix for history file configured by the `history.sh` profile script.

Switching this needlessly confuses the end users.